### PR TITLE
MIST-473 Add the callstack to error fields

### DIFF
--- a/formatter.go
+++ b/formatter.go
@@ -3,6 +3,10 @@
 package logrusx
 
 import (
+	"fmt"
+	"runtime"
+	"strings"
+
 	log "github.com/Sirupsen/logrus"
 )
 
@@ -17,6 +21,7 @@ type (
 	FieldError struct {
 		Error   error
 		Message string
+		Stack   []string
 	}
 )
 
@@ -25,8 +30,33 @@ type (
 func (f *MistifyFormatter) Format(entry *log.Entry) ([]byte, error) {
 	for k, v := range entry.Data {
 		if err, ok := v.(error); ok {
-			entry.Data[k] = FieldError{err, err.Error()}
+			// Get the call stack and remove this function call from it
+			stack := f.callStack()[1:]
+
+			entry.Data[k] = FieldError{
+				Error:   err,
+				Message: err.Error(),
+				Stack:   stack,
+			}
 		}
 	}
 	return f.JSONFormatter.Format(entry)
+}
+
+func (f *MistifyFormatter) callStack() []string {
+	stack := make([]string, 0, 4)
+	for i := 1; ; i++ {
+		pc, file, line, ok := runtime.Caller(i)
+		if !ok {
+			break
+		}
+		// Look up the function name (package.FnName)
+		fnName := runtime.FuncForPC(pc).Name()
+		// Add the line to the stack, skipping anything from within the logrus
+		// package so it starts at the log caller
+		if !strings.HasPrefix(fnName, "github.com/Sirupsen/logrus.") {
+			stack = append(stack, fmt.Sprintf("%s:%d (%s)", file, line, fnName))
+		}
+	}
+	return stack
 }


### PR DESCRIPTION
Omit from the callstack the logrus package function calls and the
formatter call so that the stack begins where the logging is called

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/mistifyio/mistify-logrus-ext/3)

<!-- Reviewable:end -->
